### PR TITLE
fix: gracefully handle missing `Navigator.keyboard` property

### DIFF
--- a/src/actions/triggerhotkey/pi.js
+++ b/src/actions/triggerhotkey/pi.js
@@ -9,7 +9,7 @@ const modifiers = {
 	Alt: false,
 	Meta: false,
 };
-const keyboardLayoutMap = await navigator.keyboard.getLayoutMap().catch(() => null);
+const keyboardLayoutMap = await navigator.keyboard?.getLayoutMap().catch(() => null);
 
 // Init shown sequence input field and add event listeners to it
 document.querySelectorAll('.sequence-item .sdpi-item-value').forEach((input) => {


### PR DESCRIPTION
Hello @theca11,

`navigator.keyboard` is undefined in some browsers, since it's a Chromium-only experimental technology right now. This causes the Hotkey Sequence action's PI not to work with [OpenDeck](https://github.com/nekename/OpenDeck) on Linux and macOS, because the Tauri framework uses WebKit, not Chromium, on those platforms.

Since the action's PI already handles failure or empty output of getLayoutMap(), it suffices to use optional chaining to handle the case where navigator.keyboard itself is undefined.

Thanks